### PR TITLE
seL4,camkes: Update CAmkES rumprun config template

### DIFF
--- a/platform/sel4/camkes/rumprun_camkes.h
+++ b/platform/sel4/camkes/rumprun_camkes.h
@@ -30,8 +30,5 @@
     attribute RumprunConfig rump_config; \
     attribute int sched_ctrl = 0;
 
-#define RUMPRUN_COMPONENT_CONFIGURATION(instance, id) \
-        instance.platform_timer_global_endpoint = VAR_STRINGIZE(instance); \
-        instance.platform_timer_attributes = id + 2; \
-        instance.platform_putchar_attributes = id;
+#define RUMPRUN_COMPONENT_CONFIGURATION(instance, id)
 


### PR DESCRIPTION
These settings are no longer required/supported by upstream camkes.

Signed-off-by: Kent McLeod <kent.mcleod@protonmail.com>